### PR TITLE
 feat/season-plugin-option

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ You can pass a `start` and `end` date to determine when the snow will start and 
     options: {
       season: {
         start: new Date("December 1, 2021 00:00:01"),
-        end: new Date("December 31, 2022 11:59:00"),
+        end: new Date("December 31, 2022 11:59:59"),
       },
     },
   },

--- a/README.md
+++ b/README.md
@@ -22,7 +22,9 @@ module.exports = {
 }
 ```
 
-## Options
+## Plugin Options
+
+### Colors
 
 You can pass an array of colors to use via the plugin options
 
@@ -33,6 +35,22 @@ You can pass an array of colors to use via the plugin options
       colors: ["#fff000", "#ff00ff", "#00ff00"],
     },
   },
+```
+
+### Season
+
+You can pass a `start` and `end` date to determine when the snow will start and end
+
+```
+    {
+      resolve: "@raae/gatsby-plugin-let-it-snow",
+      options: {
+        season: {
+          start: new Date("December 1, 2021"),
+          end: new Date("January 1, 2022"),
+        },
+      },
+    },
 ```
 
 ## How to contribute with code

--- a/README.md
+++ b/README.md
@@ -42,15 +42,15 @@ You can pass an array of colors to use via the plugin options
 You can pass a `start` and `end` date to determine when the snow will start and end
 
 ```
-    {
-      resolve: "@raae/gatsby-plugin-let-it-snow",
-      options: {
-        season: {
-          start: new Date("December 1, 2021"),
-          end: new Date("January 1, 2022"),
-        },
+  {
+    resolve: "@raae/gatsby-plugin-let-it-snow",
+    options: {
+      season: {
+        start: new Date("December 1, 2021 00:00:01"),
+        end: new Date("December 31, 2022 11:59:00"),
       },
     },
+  },
 ```
 
 ## Powered by Canvas Confetti 🎉

--- a/README.md
+++ b/README.md
@@ -46,8 +46,8 @@ You can pass a `start` and `end` date to determine when the snow will start and 
     resolve: "@raae/gatsby-plugin-let-it-snow",
     options: {
       season: {
-        start: new Date("December 1, 2021 00:00:01"),
-        end: new Date("December 31, 2022 11:59:59"),
+        start: new Date("December 1, 2021 00:00:10"),
+        end: new Date("December 31, 2021 23:59:50"),
       },
     },
   },

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ module.exports = {
 
 ### Colors
 
-You can pass an array of colors to use via the plugin options
+You can pass an array of colors to use via the plugin options.
 
 ```
   {
@@ -39,7 +39,8 @@ You can pass an array of colors to use via the plugin options
 
 ### Season
 
-You can pass a `start` and `end` date to determine when the snow will start and end
+You can pass a `start` and `end` date to determine when the snow will start and end.
+Note: Year will be ignored, and snow will fall each year within the configured season.
 
 ```
   {

--- a/demo/gatsby-config.js
+++ b/demo/gatsby-config.js
@@ -1,3 +1,14 @@
 module.exports = {
-  plugins: ["@raae/gatsby-plugin-let-it-snow"],
+  plugins: [
+    {
+      resolve: "@raae/gatsby-plugin-let-it-snow",
+      options: {
+        colors: ["#fff", "#ffb6c1"],
+        season: {
+          start: new Date("December 2, 2023"),
+          end: new Date("January 11, 2024"),
+        },
+      },
+    },
+  ],
 };

--- a/plugin/gatsby-browser.js
+++ b/plugin/gatsby-browser.js
@@ -10,13 +10,6 @@ import {
   parseISO,
 } from "date-fns";
 
-const SEASON = {
-  start: new Date("December 1"),
-  end: new Date("January 4"),
-};
-
-const COLORS = ["#fff"];
-
 const isSeason = ({ start, end }) => {
   const currentDate = new Date();
   const currentYear = getYear(currentDate);
@@ -36,7 +29,7 @@ const isSeason = ({ start, end }) => {
 };
 
 export const onInitialClientRender = (_, options) => {
-  const { colors = COLORS, season = SEASON } = options;
+  const { colors, season } = options;
 
   if (!isSeason(season)) {
     return;

--- a/plugin/gatsby-browser.js
+++ b/plugin/gatsby-browser.js
@@ -1,9 +1,46 @@
 // https://www.gatsbyjs.com/docs/reference/config-files/gatsby-browser/
 
 import confetti from "canvas-confetti";
+import {
+  addYears,
+  getYear,
+  setYear,
+  isBefore,
+  isWithinInterval,
+  parseISO,
+} from "date-fns";
+
+const SEASON = {
+  start: new Date("December 1"),
+  end: new Date("January 4"),
+};
+
+const COLORS = ["#fff"];
+
+const isSeason = ({ start, end }) => {
+  const currentDate = new Date();
+  const currentYear = getYear(currentDate);
+
+  // Ignore year from config dates
+  const startDate = setYear(parseISO(start), currentYear);
+  let endDate = setYear(parseISO(end), currentYear);
+
+  if (isBefore(endDate, startDate)) {
+    endDate = addYears(endDate, 1);
+  }
+
+  return isWithinInterval(currentDate, {
+    start: startDate,
+    end: endDate,
+  });
+};
 
 export const onInitialClientRender = (_, options) => {
-  const { colors = ["#ffffff"], season } = options;
+  const { colors = COLORS, season = SEASON } = options;
+
+  if (!isSeason(season)) {
+    return;
+  }
 
   const now = Date.now();
   const duration = 15 * 1000;
@@ -41,14 +78,5 @@ export const onInitialClientRender = (_, options) => {
     }
   };
 
-  if (season) {
-    if (
-      new Date(now).getTime() >= new Date(season.start).getTime() &&
-      new Date(now).getTime() <= new Date(season.end).getTime()
-    ) {
-      frame();
-    }
-  } else {
-    frame();
-  }
+  frame();
 };

--- a/plugin/gatsby-browser.js
+++ b/plugin/gatsby-browser.js
@@ -11,21 +11,29 @@ import {
 } from "date-fns";
 
 const isSeason = ({ start, end }) => {
-  const currentDate = new Date();
-  const currentYear = getYear(currentDate);
+  try {
+    const currentDate = new Date();
+    const currentYear = getYear(currentDate);
 
-  // Ignore year from config dates
-  const startDate = setYear(parseISO(start), currentYear);
-  let endDate = setYear(parseISO(end), currentYear);
+    // Ignore year from config dates
+    const startDate = setYear(parseISO(start), currentYear);
+    let endDate = setYear(parseISO(end), currentYear);
 
-  if (isBefore(endDate, startDate)) {
-    endDate = addYears(endDate, 1);
+    if (isBefore(endDate, startDate)) {
+      endDate = addYears(endDate, 1);
+    }
+
+    return isWithinInterval(currentDate, {
+      start: startDate,
+      end: endDate,
+    });
+  } catch (error) {
+    console.warn(
+      "Problem with @raae/gatsby-plugin-let-it-snow season configuration:",
+      error.message
+    );
+    return false;
   }
-
-  return isWithinInterval(currentDate, {
-    start: startDate,
-    end: endDate,
-  });
 };
 
 export const onInitialClientRender = (_, options) => {

--- a/plugin/gatsby-browser.js
+++ b/plugin/gatsby-browser.js
@@ -3,10 +3,11 @@
 import confetti from "canvas-confetti";
 
 export const onInitialClientRender = (_, options) => {
-  const { colors = ["#ffffff"] } = options;
+  const { colors = ["#ffffff"], season } = options;
 
+  const now = Date.now();
   const duration = 15 * 1000;
-  const animationEnd = Date.now() + duration;
+  const animationEnd = now + duration;
   let skew = 1;
 
   function randomInRange(min, max) {
@@ -14,7 +15,7 @@ export const onInitialClientRender = (_, options) => {
   }
 
   const frame = () => {
-    const timeLeft = animationEnd - Date.now();
+    const timeLeft = animationEnd - now;
     const ticks = Math.max(200, 500 * (timeLeft / duration));
     skew = Math.max(0.8, skew - 0.001);
 
@@ -40,5 +41,14 @@ export const onInitialClientRender = (_, options) => {
     }
   };
 
-  frame();
+  if (season) {
+    if (
+      new Date(now).getTime() >= new Date(season.start).getTime() &&
+      new Date(now).getTime() <= new Date(season.end).getTime()
+    ) {
+      frame();
+    }
+  } else {
+    frame();
+  }
 };

--- a/plugin/gatsby-node.js
+++ b/plugin/gatsby-node.js
@@ -3,12 +3,13 @@ exports.pluginOptionsSchema = ({ Joi }) => {
   return Joi.object({
     colors: Joi.array()
       .items(Joi.string())
+      .min(1)
       .default(["#fff"])
       .description("Array of hex color values"),
     season: Joi.object()
       .keys({
-        start: Joi.date(),
-        end: Joi.date(),
+        start: Joi.date().required(),
+        end: Joi.date().required(),
       })
       .default({
         start: new Date("December 1"),

--- a/plugin/gatsby-node.js
+++ b/plugin/gatsby-node.js
@@ -4,5 +4,11 @@ exports.pluginOptionsSchema = ({ Joi }) => {
     colors: Joi.array()
       .items(Joi.string().default("#ffffff"))
       .description("Array of hex color values"),
+    season: Joi.object()
+      .keys({
+        start: Joi.date(),
+        end: Joi.date(),
+      })
+      .description("Start and end date for when snow should be visible"),
   });
 };

--- a/plugin/gatsby-node.js
+++ b/plugin/gatsby-node.js
@@ -2,12 +2,17 @@
 exports.pluginOptionsSchema = ({ Joi }) => {
   return Joi.object({
     colors: Joi.array()
-      .items(Joi.string().default("#ffffff"))
+      .items(Joi.string())
+      .default(["#fff"])
       .description("Array of hex color values"),
     season: Joi.object()
       .keys({
         start: Joi.date(),
         end: Joi.date(),
+      })
+      .default({
+        start: new Date("December 1"),
+        end: new Date("January 4"),
       })
       .description("Start and end date for when snow should be visible"),
   });

--- a/plugin/package.json
+++ b/plugin/package.json
@@ -23,5 +23,8 @@
   "dependencies": {
     "canvas-confetti": "1.4.0",
     "date-fns": "2.27.0"
+  },
+  "peerDependencies": {
+    "gatsby": "^2.4.0 || ^3.0.0 || ^4.0.0"
   }
 }

--- a/plugin/package.json
+++ b/plugin/package.json
@@ -21,6 +21,7 @@
     "gatsby-plugin"
   ],
   "dependencies": {
-    "canvas-confetti": "1.4.0"
+    "canvas-confetti": "1.4.0",
+    "date-fns": "2.27.0"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -4071,6 +4071,11 @@ dataloader@2.0.0:
   resolved "https://registry.yarnpkg.com/dataloader/-/dataloader-2.0.0.tgz#41eaf123db115987e21ca93c005cd7753c55fe6f"
   integrity sha512-YzhyDAwA4TaQIhM5go+vCLmU0UikghC/t9DTQYZR2M/UvZ1MdOhPezSDZcjj9uqQJOMqjLcpWtyW2iNINdlatQ==
 
+date-fns@2.27.0:
+  version "2.27.0"
+  resolved "https://registry.yarnpkg.com/date-fns/-/date-fns-2.27.0.tgz#e1ff3c3ddbbab8a2eaadbb6106be2929a5a2d92b"
+  integrity sha512-sj+J0Mo2p2X1e306MHq282WS4/A8Pz/95GIFcsPNMPMZVI3EUrAdSv90al1k+p74WGLCruMXk23bfEDZa71X9Q==
+
 date-fns@^2.25.0:
   version "2.25.0"
   resolved "https://registry.yarnpkg.com/date-fns/-/date-fns-2.25.0.tgz#8c5c8f1d958be3809a9a03f4b742eba894fc5680"


### PR DESCRIPTION
- add season `start` and `end`

The only slight snag with this is: 

When a user sets the dates via the plugin options it **must** be a valid date object which includes the year. Naturally, next year this wouldn't start the snow unless the user changes the year in the options

```javascript
    {
      resolve: "@raae/gatsby-plugin-let-it-snow",
      options: {
        season: {
          start: new Date("December 1, 2021"), // date including year
          end: new Date("January 1, 2022"), // date including year
        },
      },
    },
```