### PR TITLE
chore/add-peer-deps

### DIFF
--- a/plugin/package.json
+++ b/plugin/package.json
@@ -22,5 +22,8 @@
   ],
   "dependencies": {
     "canvas-confetti": "1.4.0"
+  },
+  "peerDependencies": {
+    "gatsby": "^3.0.0 || ^4.0.0"
   }
 }


### PR DESCRIPTION
- add `peerDependencies` to `package.json`


I'm not 100% on this but i think this will also be compatible with Gatsby 2 but i haven't checked. 

```javascript
  "peerDependencies": {
    "gatsby": "^2.0.0 || ^3.0.0 || ^4.0.0"
  }
```